### PR TITLE
Tx status 'removed-from-pool' removed and changed to 'pending'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.version

--- a/rewards-service/.gitignore
+++ b/rewards-service/.gitignore
@@ -2,6 +2,8 @@
 dist/
 exec/
 
+# temp build artifacts
+.version
 
 # Logs
 logs

--- a/rewards-service/src/distributor/send.test.ts
+++ b/rewards-service/src/distributor/send.test.ts
@@ -211,7 +211,7 @@ describe('sendTransactionBatch', () => {
         SendTime: expect.any(Number),
         GasPriceStrategy: 'discount',
         GasPrice: 24000000000,
-        Status: 'removed-from-pool',
+        Status: 'timeout', // this used to return error
         TxHash: '0xtxHash',
         EthBlock: 0,
         DistributionName: '6666-7777',

--- a/rewards-service/src/distributor/send.ts
+++ b/rewards-service/src/distributor/send.ts
@@ -168,12 +168,7 @@ async function readPendingTransactionStatus(web3: Web3, status: EthereumTxStatus
 
   // needed since getTransactionReceipt fails on light client when tx is pending
   const tx = await web3.eth.getTransaction(status.TxHash);
-  if (tx == null) {
-    Logger.error(`Last ethereum tx ${status.TxHash} removed from pool.`);
-    status.Status = 'removed-from-pool';
-    return;
-  }
-  if (tx.blockNumber == null) {
+  if (tx == null || tx.blockNumber == null) {
     Logger.log(`Last ethereum tx ${status.TxHash} is still waiting for block.`);
     handlePendingTxTimeout(status, config);
     return; // still pending

--- a/rewards-service/src/model/state.ts
+++ b/rewards-service/src/model/state.ts
@@ -17,7 +17,7 @@ export class State {
 
 export type GasPriceStrategy = 'discount' | 'recommended';
 
-export type TransactionStatus = 'pending' | 'successful' | 'failed-send' | 'timeout' | 'removed-from-pool' | 'revert';
+export type TransactionStatus = 'pending' | 'successful' | 'failed-send' | 'timeout' | 'revert';
 
 export interface DistributionStats {
   DistributionName: string;


### PR DESCRIPTION
‘removed-from-pool’ tx status changed because it caused false positives (query arrived to node who didn’t see the tx yet), and on false positive we would retransmit the tx